### PR TITLE
Switch LLM summarization from Hugging Face to OpenAI API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,11 +5,17 @@ go 1.23
 toolchain go1.23.4
 
 require (
+	github.com/joho/godotenv v1.5.1
+	github.com/openai/openai-go v0.1.0-beta.10
 	github.com/redis/go-redis/v9 v9.7.0
-	golang.org/x/net v0.32.0
+	golang.org/x/net v0.34.0
 )
 
 require (
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
+	github.com/tidwall/gjson v1.14.4 // indirect
+	github.com/tidwall/match v1.1.1 // indirect
+	github.com/tidwall/pretty v1.2.1 // indirect
+	github.com/tidwall/sjson v1.2.5 // indirect
 )


### PR DESCRIPTION
This PR migrates the paper summarization functionality from the Hugging Face Router API to the official OpenAI API.

Key changes include:

-   Updated the `summarizeWithLLM` function to use the `openai-go` library (`v0.1.0-beta.10`).
-   Modified API call parameters to use the correct helper functions (`openai.Int`, `openai.Float`) for optional fields like `Temperature` and `TopP`.
-   Added the `godotenv` library to load API keys and other configuration (`KV_URL`, `UPDATE_KEY`) from a `.env` file, facilitating local development.
-   Updated `go.mod` with the new dependencies (`openai-go`, `godotenv`) and ran `go mod tidy` to ensure correct dependency management.
