### PR TITLE
refactor: link validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .env
 .vercel
 go.sum
+.DS_Store


### PR DESCRIPTION
## Describe your changes
What was changed and why this change was needed

- **What**: 

Validation was added to unify links and make the generation more repeatable. We have created some regex patterns and removed the dependency for the LLM to write the link out again.

- **Why**:

This was done to prevent this issue:


The standout is R-Zero, a self-evolving language model framework that autonomously generates and learns from its own training data, boosting reasoning scores by over 6 points on key benchmarks—imagine AI that teaches itself without human-labeled data! ***([R-Zero: Self-Evolving Reasoning LLM from Zero Data](https://tldr.takara.ai/p/2508.05004)(https://huggingface.co/papers/2508.05004)).***

The link here is not formatted correctly and this was an LLM problem.


## Issue ticket number and link

## Checklist before requesting a review
- [x] PR title follows conventional commit format (e.g., `feat: add user authentication`, `fix: resolve API timeout`)
- [x] I have performed a self-review of my code
- [x] Tests pass
- [x] Documentation updated if needed 